### PR TITLE
Generate valid JSON if partition table is empty

### DIFF
--- a/libfdisk/src/script.c
+++ b/libfdisk/src/script.c
@@ -604,7 +604,7 @@ static int write_file_json(struct fdisk_script *dp, FILE *f)
 		else
 			fputs(fi->data, f);
 
-		if (!dp->table && fi == list_last_entry(&dp->headers, struct fdisk_scriptheader, headers))
+		if ((fi == list_last_entry(&dp->headers, struct fdisk_scriptheader, headers)) && (!dp->table || fdisk_table_is_empty(dp->table)))
 			fputc('\n', f);
 		else
 			fputs(",\n", f);


### PR DESCRIPTION
When the partition table is present **but** empty, the existing code would output fields followed by a `,` , on the assumption that the list of partitions would follow. But if the list of partitions is empty, it is skipped, leading to output like this:

```
{
  "partitiontable": {
      "label":"gpt",
      "id":"1F9E80D9-DD78-024F-94A3-B61EC82B18C8",
      "device":"/dev/sdb",
      "unit":"sectors",
      "firstlba":2048,
      "lastlba":30949342,
      "sectorsize":512,
  }
}
```

Note the `512,` on the *sectorsize* line.

This is invalid JSON for some parsers, which choke on it.

Avoid this, by checking when outputting the last separator: if there's no table, or there is a table but it is empty, then just put a newline, otherwise use the old path of comma-newline and assume there's going to be a list of partitions after.